### PR TITLE
[修正] 盤面更新時の起点が間違っていたため修正

### DIFF
--- a/frontend/src/othello.rs
+++ b/frontend/src/othello.rs
@@ -6,8 +6,8 @@ use crate::othello::State::{Black, Empty, White};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Pos {
-    x: i8,
-    y: i8
+    pub(crate) x: i8,
+    pub(crate) y: i8
 }
 
 impl Pos {
@@ -121,9 +121,10 @@ impl Board {
                     }
                     log(&format!("search,{:?}", pos));
                     if (target == Black && self.is_black) || (target == White && !self.is_black) {
-                        let mut _pos = pos.new_offset(offset_x,offset_y);
+                        let mut _pos = current_pos.new_offset(offset_x,offset_y);
                         while is_in_board(_pos) {
                             self.update(_pos);
+                            log(&format!("update,{:?}, target: {:?}", _pos, pos));
                             _pos.apply_offset(offset_x,offset_y);
                             if _pos.x == pos.x {
                                 break;

--- a/frontend/src/othello.rs
+++ b/frontend/src/othello.rs
@@ -126,7 +126,7 @@ impl Board {
                             self.update(_pos);
                             log(&format!("update,{:?}, target: {:?}", _pos, pos));
                             _pos.apply_offset(offset_x,offset_y);
-                            if _pos.x == pos.x {
+                            if _pos.x == pos.x && _pos.y == pos.y {
                                 break;
                             }
                         }


### PR DESCRIPTION
盤面を更新する際、探査後初期位置から目標位置まで更新をかけるはずが、目標位置から処理が開始してしまっていたため修正